### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/pwndb.py
+++ b/pwndb.py
@@ -54,7 +54,7 @@ def find(email):
             password = result.get('password', '')
             where = result.get('where', ' ')
             print(good + "  " + username + "@" + domain + ":" + password + " " + W + where)
-    except Exception, e:
+    except Exception as e:
         print(bad + " Can't connect to service! restart tor service and try again")
         exit(0)
 


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.