### PR TITLE
Added cast to string to show error message when an exception arises

### DIFF
--- a/pwndb.py
+++ b/pwndb.py
@@ -136,4 +136,4 @@ if __name__ == '__main__':
     except ConnectionError:
         print(bad + " Can't connect to service! restart tor service and try again.")
     except Exception as e:
-        print(bad + " " + e)
+        print(bad + " " + str(e))


### PR DESCRIPTION
When getting an exception (not related with connection problems) the error message is not displayed, instead a message "TypeError: can only concatenate str (not "InvalidSchema") to str" appears.
I got this error running the program before installing the PySocks package but it could happen with other exceptions, I hope this helps!