### PR TITLE
Made error message more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ pwndb.py is a python command-line tool for searching leaked credentials using th
 ## Usage
 
 ```bash
-usage: pwndb.py [-h] [--target TARGET] [--list LIST] [--output OUTPUT]
+usage: pwndb.py [-h] [--target TARGET] [--list LIST] [--output OUTPUT] [--proxy PROXY]
 
 optional arguments:
   -h, --help       show this help message and exit
   --target TARGET  Target email/domain to search for leaks.
   --list LIST      A list of emails in a file to search for leaks.
   --output OUTPUT  Return results as json/txt
+  --proxy PROXY    Set Tor proxy (default: 127.0.0.1:9150)
 ```
 
 > Note: tor service must be up and running to be connected to port 9050
@@ -43,13 +44,14 @@ Collecting PySocks==1.6.8 (from -r requirements.txt (line 1))
 
 (venv) $ python pwndb.py -h
 
-usage: pwndb.py [-h] [--target TARGET] [--list LIST] [--output OUTPUT]
+usage: pwndb.py [-h] [--target TARGET] [--list LIST] [--output OUTPUT] [--proxy PROXY]
 
 optional arguments:
   -h, --help       show this help message and exit
   --target TARGET  Target email/domain to search for leaks.
   --list LIST      A list of emails in a file to search for leaks.
   --output OUTPUT  Return results as json/txt
+  --proxy PROXY    Set Tor proxy (default: 127.0.0.1:9150)
 ```
 
 ## Contributing

--- a/pwndb.py
+++ b/pwndb.py
@@ -134,6 +134,6 @@ if __name__ == '__main__':
     try:
         main(emails, output)
     except ConnectionError:
-        print(bad + " Can't connect to service! restart tor service and try again.")
+        print(bad + " Can't connect to service! Make sure Tor socks proxy is listening on " + proxy)
     except Exception as e:
         print(bad + " " + str(e))


### PR DESCRIPTION
There are open issues regarding the error message "Can't connect to service! restart tor service and try again.". 

The reason is people are not using the correct port number for Tor socks proxy. They just need to change 9050 to 9150 or whatever the port number Tor socks proxy is listening on.

Therefore, I updated the command help message in Readme file to include --proxy parameter. And I also changed the error message to help people understand why they cannot connect to Tor service.